### PR TITLE
Remove group cleaning code left over from legacy implementation

### DIFF
--- a/action/search.php
+++ b/action/search.php
@@ -175,7 +175,6 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         // groups exclusion SHOULD be respected, not MUST, since that would not allow for exceptions
         $groupExcludeSubquery = new \Elastica\Query\BoolQuery();
         foreach($groups as $group) {
-            $group  = str_replace('-', '', strtolower($group));
             $term = new \Elastica\Query\Term();
             $term->setTerm('groups_exclude', $group);
             $groupExcludeSubquery->addShould($term);


### PR DESCRIPTION
relates to 1009c13906b9f169afbd75386b1bb0c44a8b149b