### PR TITLE
Make sure ACL fields are searched 'as-is'

### DIFF
--- a/helper/client.php
+++ b/helper/client.php
@@ -87,8 +87,10 @@ class helper_plugin_elasticsearch_client extends DokuWiki_Plugin {
     public function createIndex($clear=false) {
         $client = $this->connect();
         $index = $client->getIndex($this->getConf('indexname'));
-        $response = $index->create(array(), $clear);
-        return $response;
+
+        $index->create([], $clear);
+
+        return $this->mapAccessFields($index);
     }
 
     /**
@@ -148,6 +150,40 @@ class helper_plugin_elasticsearch_client extends DokuWiki_Plugin {
     {
         if (isset(self::ANALYZERS[$lang])) return self::ANALYZERS[$lang];
         return 'standard';
+    }
+
+    /**
+     * Define special mappings for ACL fields
+     *
+     * Standard mapping could break the search because ACL fields
+     * might contain word-split tokens such as underscores and so must not
+     * be indexed using the standard text analyzer.
+     *
+     * @param \Elastica\Index $index
+     * @return \Elastica\Response
+     */
+    protected function mapAccessFields(\Elastica\Index $index): \Elastica\Response
+    {
+        $type = $index->getType($this->getConf('documenttype'));
+        $props = [
+            'groups_include' => [
+                'type' => 'keyword',
+            ],
+            'groups_exclude' => [
+                'type' => 'keyword',
+            ],
+            'users_include' => [
+                'type' => 'keyword',
+            ],
+            'users_exclude' => [
+                'type' => 'keyword',
+            ],
+        ];
+
+        $mapping = new \Elastica\Type\Mapping();
+        $mapping->setType($type);
+        $mapping->setProperties($props);
+        return $mapping->send();
     }
 }
 


### PR DESCRIPTION
ACL fields must NOT be indexed as natural language, with word splitting etc. but this is what standard mapping results in. This PR explicitly defines simple keyword mapping for those fields, which will prevent that behavior.

This PR could fix #3 if the user's problem is caused by special characters in usergroup names.