### PR TITLE
Use rendered content instead of raw syntax if possible

### DIFF
--- a/action/indexing.php
+++ b/action/indexing.php
@@ -168,7 +168,16 @@ class action_plugin_elasticsearch_indexing extends DokuWiki_Action_Plugin {
         $data['user']     = $meta['user'];
         $data['title']    = $meta['title'];
         $data['abstract'] = $meta['description']['abstract'];
-        $data['content']  = rawWiki($id);
+        $data['syntax']   = rawWiki($id);
+
+        // prefer rendered plaintext over raw syntax output
+        /** @var \renderer_plugin_text $textRenderer */
+        $textRenderer = plugin_load('renderer', 'text');
+        if ($textRenderer) {
+            $data['content'] = p_cached_output(wikiFN($id),'text');
+        } else {
+            $data['content']  = $data['syntax'];
+        }
 
         /** @var helper_plugin_translation $trans */
         $trans = plugin_load('helper', 'translation');

--- a/action/search.php
+++ b/action/search.php
@@ -95,9 +95,15 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         Event::createAndTrigger('PLUGIN_ELASTICSEARCH_QUERY', $additions);
         // if query is empty, return all results
         if (empty($QUERY)) $QUERY = '*';
-        // let plugins add their fields to query
+
+        // get fields to use in query
         $fields = [];
         Event::createAndTrigger('PLUGIN_ELASTICSEARCH_SEARCHFIELDS', $fields);
+
+        if ($this->getConf('searchSyntax')) {
+            array_push($this->searchFields, 'syntax');
+        }
+
         // finally define the elastic query
         $qstring = new \Elastica\Query\SimpleQueryString($QUERY, array_merge($this->searchFields, $fields));
         // restore the original query

--- a/conf/default.php
+++ b/conf/default.php
@@ -9,6 +9,7 @@ $conf['servers']      = 'localhost:9200';
 $conf['indexname']    = 'wiki';
 $conf['documenttype'] = 'wikipage';
 $conf['snippets']     = 'content';
+$conf['searchSyntax'] = 1;
 $conf['perpage']      = 20;
 $conf['debug']        = 0;
 

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -9,6 +9,7 @@ $meta['servers']      = array();
 $meta['indexname']    = array('string');
 $meta['documenttype'] = array('string');
 $meta['snippets']     = array('multichoice', '_choices' => array('content','abstract'));
+$meta['searchSyntax'] = array('onoff');
 $meta['perpage']      = array('numeric', '_min' => 1);
 $meta['debug']        = array('onoff');
 

--- a/helper/client.php
+++ b/helper/client.php
@@ -60,20 +60,20 @@ class helper_plugin_elasticsearch_client extends DokuWiki_Plugin {
      * @return \Elastica\Client
      */
     public function connect() {
-        if(!is_null($this->elasticaClient)) return $this->elasticaClient;
+        if (!is_null($this->elasticaClient)) return $this->elasticaClient;
 
         // parse servers config into DSN array
         $dsn = ['servers' => []];
         $servers = $this->getConf('servers');
         $lines   = explode("\n", $servers);
-        foreach($lines as $line) {
-            list($host, $proxy) = explode(',', $line, 2);
+        foreach ($lines as $line) {
+            list($host, $proxy) = array_pad(explode(',', $line, 2),2, null);
             list($host, $port) = explode(':', $host, 2);
             $host = trim($host);
             $port = (int) trim($port);
-            if(!$port) $port = 80;
+            if (!$port) $port = 80;
             $proxy = trim($proxy);
-            if(!$host) continue;
+            if (!$host) continue;
             $dsn['servers'][] = compact('host', 'port', 'proxy');
         }
 

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -6,7 +6,9 @@
  */
 
 $lang['servers']      = 'ElasticSearch server: einer pro Zeile, Port-Nummer durch Doppelpunkt getrennt, optionaler Proxy nach einem Komma';
-$lang['indexname']    = 'Zu benutzener Index-Name. Muss existieren oder kann mit dem cli.php tool erzeugt werden.';
+$lang['indexname']    = 'Zu benutzender Index-Name. Muss existieren oder kann mit dem cli.php tool erzeugt werden.';
 $lang['documenttype'] = 'Dokumententyp unter dem die Wikiseiten abgelegt werden sollen';
+$lang['snippets']     = 'Text, der in den Suchergebnissen als Vorschau angezeigt wird';
+$lang['searchSyntax'] = 'Wiki-Syntax zusätzlich zum Seiteninhalt durchsuchen';
 $lang['perpage']      = 'Anzahl der Treffer pro Seite';
 $lang['debug']        = 'Debugging messages nach data/cache/debug.log schreiben - benötigt eingeschaltete allowdebug Option';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -8,5 +8,7 @@
 $lang['servers']      = 'ElasticSearch servers: one per line, add port number after a colon, give optional proxy after a comma';
 $lang['indexname']    = 'Index name to use, must exist or can be created with the cli.php tool.';
 $lang['documenttype'] = 'Document type to use when indexing';
+$lang['snippets']     = 'Text to show in search result snippets';
+$lang['searchSyntax'] = 'Search in wiki syntax in addition to page content';
 $lang['perpage']      = 'How many hits to show per page';
 $lang['debug']        = 'Log messages to data/cache/debug.log - needs allowdebug enabled';


### PR DESCRIPTION
Prerequisite: text plugin.

If it is installed, the rendered page text will be indexed as `content`. Raw wiki syntax will still be indexed in an additional field `syntax` for possible **future** use, e.g. "Search in wiki syntax" option in advanced search. This option is **not** part of this PR.