### PR TITLE
Index plugin data related to pages but stored elsewhere, e.g. tags in DB

### DIFF
--- a/action/indexing.php
+++ b/action/indexing.php
@@ -63,8 +63,6 @@ class action_plugin_elasticsearch_indexing extends DokuWiki_Action_Plugin {
     /**
      * Check if the page $id has changed since the last indexing.
      *
-     * FIXME we must be cleverer now because we let plugins contribute to index
-     *
      * @param string $id
      * @return boolean
      */

--- a/action/indexing.php
+++ b/action/indexing.php
@@ -8,6 +8,8 @@
  */
 
 // must be run within Dokuwiki
+use dokuwiki\Extension\Event;
+
 if(!defined('DOKU_INC')) die();
 
 class action_plugin_elasticsearch_indexing extends DokuWiki_Action_Plugin {

--- a/action/search.php
+++ b/action/search.php
@@ -6,13 +6,24 @@
  * @author  Andreas Gohr <gohr@cosmocode.de>
  */
 
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
+use dokuwiki\Extension\Event;
 
 /**
  * Main search helper
  */
 class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
+
+    /**
+     * Example array element for search field 'tagging':
+     * 'tagging' => [                       // also used as search query parameter
+     *   'label' => 'Tag',
+     *   'fieldPath' => 'tagging',          // dot notation in more complex mappings
+     *   'limit' => '50',
+     * ]
+     *
+     * @var Array
+     */
+    protected static $pluginSearchConfigs;
 
     /**
      * Registers a callback function for a given event
@@ -34,7 +45,7 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
      * @param $param
      */
     public function handle_preprocess(Doku_Event $event, $param) {
-        if($event->data != 'search') return;
+        if ($event->data !== 'search') return;
         $event->preventDefault();
         $event->stopPropagation();
     }
@@ -46,7 +57,7 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
      * @param $param
      */
     public function handle_action(Doku_Event $event, $param) {
-        if($event->data != 'search') return;
+        if ($event->data !== 'search') return;
         $event->preventDefault();
         $event->stopPropagation();
         global $QUERY;
@@ -56,11 +67,11 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         if (empty($QUERY)) $QUERY = $INPUT->str('q');
         if (empty($QUERY)) $QUERY = $ID;
 
+        // get extended search configurations from plugins
+        Event::createAndTrigger('PLUGIN_ELASTICSEARCH_FILTERS', self::$pluginSearchConfigs);
+
         /** @var helper_plugin_elasticsearch_client $hlp */
         $hlp = plugin_load('helper', 'elasticsearch_client');
-
-        /** @var helper_plugin_elasticsearch_form $hlpform */
-        $hlpform = plugin_load('helper', 'elasticsearch_form');
 
         $client = $hlp->connect();
         $index  = $client->getIndex($this->getConf('indexname'));
@@ -99,9 +110,9 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         if($INPUT->has('ns')) {
             $nsSubquery = new \Elastica\Query\BoolQuery();
             foreach($INPUT->arr('ns') as $ns) {
-                $term = new \Elastica\Query\Term();
-                $term->setTerm('namespace', $ns);
-                $nsSubquery->addShould($term);
+                $eterm = new \Elastica\Query\Term();
+                $eterm->setTerm('namespace', $ns);
+                $nsSubquery->addShould($eterm);
             }
             $equery->setPostFilter($nsSubquery);
         }
@@ -114,15 +125,60 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         $agg->setSize(25);
         $equery->addAggregation($agg);
 
+        // add search configurations from other plugins
+        $this->addPluginConfigurations($equery);
+
         try {
             $result = $index->search($equery);
             $aggs = $result->getAggregations();
 
             $this->print_intro();
-            $hlpform->tpl($aggs['namespace']['buckets'] ?: []);
+            /** @var helper_plugin_elasticsearch_form $hlpform */
+            $hlpform = plugin_load('helper', 'elasticsearch_form');
+            $hlpform->tpl($aggs);
             $this->print_results($result) && $this->print_pagination($result);
         } catch(Exception $e) {
             msg('Something went wrong on searching please try again later or ask an admin for help.<br /><pre>' . hsc($e->getMessage()) . '</pre>', -1);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function getRawPluginSearchConfigs()
+    {
+        return self::$pluginSearchConfigs;
+    }
+
+    /**
+     * Add search configurations supplied by other plugins
+     *
+     * @param \Elastica\Query $equery
+     */
+    protected function addPluginConfigurations($equery)
+    {
+        global $INPUT;
+
+        if (!empty(self::$pluginSearchConfigs)) {
+            foreach (self::$pluginSearchConfigs as $param => $config) {
+                // handle search parameter
+                if ($INPUT->has($param)) {
+                    $pluginSubquery = new \Elastica\Query\BoolQuery();
+                    foreach($INPUT->arr($param) as $item) {
+                        $eterm = new \Elastica\Query\Term();
+                        $eterm->setTerm($param, $item);
+                        $pluginSubquery->addShould($eterm);
+                    }
+                    $equery->setPostFilter($pluginSubquery);
+                }
+                // build aggregation for use as filter in advanced search
+                $agg = new \Elastica\Aggregation\Terms($param);
+                $agg->setField($config['fieldPath']);
+                if (isset($config['limit'])) {
+                    $agg->setSize($config['limit']);
+                }
+                $equery->addAggregation($agg);
+            }
         }
     }
 
@@ -134,7 +190,6 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
      */
     protected function addDateSubquery($subqueries, $min)
     {
-        // FIXME
         if (!in_array($min, ['year', 'month', 'week'])) return;
 
         $dateSubquery = new \Elastica\Query\Range(

--- a/action/search.php
+++ b/action/search.php
@@ -26,6 +26,18 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
     protected static $pluginSearchConfigs;
 
     /**
+     * Search will be performed on those fields only.
+     *
+     * @var string[]
+     */
+    protected $searchFields = [
+        'title',
+        'abstract',
+        'content',
+        'uri',
+    ];
+
+    /**
      * Registers a callback function for a given event
      *
      * @param Doku_Event_Handler $controller DokuWiki's event controller object
@@ -83,8 +95,11 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         Event::createAndTrigger('PLUGIN_ELASTICSEARCH_QUERY', $additions);
         // if query is empty, return all results
         if (empty($QUERY)) $QUERY = '*';
-        // finally define the elastic query string
-        $qstring = new \Elastica\Query\SimpleQueryString($QUERY);
+        // let plugins add their fields to query
+        $fields = [];
+        Event::createAndTrigger('PLUGIN_ELASTICSEARCH_SEARCHFIELDS', $fields);
+        // finally define the elastic query
+        $qstring = new \Elastica\Query\SimpleQueryString($QUERY, array_merge($this->searchFields, $fields));
         // restore the original query
         $QUERY = $q;
         // append additions provided by plugins

--- a/action/search.php
+++ b/action/search.php
@@ -79,13 +79,18 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         // store copy of the original query string
         $q = $QUERY;
         // let plugins manipulate the query
-        Event::createAndTrigger('PLUGIN_ELASTICSEARCH_QUERY', $eventData);
+        $additions = [];
+        Event::createAndTrigger('PLUGIN_ELASTICSEARCH_QUERY', $additions);
         // if query is empty, return all results
         if (empty($QUERY)) $QUERY = '*';
         // finally define the elastic query string
         $qstring = new \Elastica\Query\SimpleQueryString($QUERY);
         // restore the original query
         $QUERY = $q;
+        // append additions provided by plugins
+        if (!empty($additions)) {
+            $QUERY .= ' ' . implode(' ', $additions);
+        }
 
         // create the actual search object
         $equery = new \Elastica\Query();

--- a/action/search.php
+++ b/action/search.php
@@ -76,8 +76,16 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         $client = $hlp->connect();
         $index  = $client->getIndex($this->getConf('indexname'));
 
-        // define the query string
+        // store copy of the original query string
+        $q = $QUERY;
+        // let plugins manipulate the query
+        Event::createAndTrigger('PLUGIN_ELASTICSEARCH_QUERY', $eventData);
+        // if query is empty, return all results
+        if (empty($QUERY)) $QUERY = '*';
+        // finally define the elastic query string
         $qstring = new \Elastica\Query\SimpleQueryString($QUERY);
+        // restore the original query
+        $QUERY = $q;
 
         // create the actual search object
         $equery = new \Elastica\Query();

--- a/helper/plugins.php
+++ b/helper/plugins.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * DokuWiki Plugin elasticsearch (Plugins Helper Component)
+ *
+ * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
+ * @author  Andreas Gohr <gohr@cosmocode.de>
+ * @author  Anna Dabrowska <dabrowska@cosmocode.de>
+ */
+
+class helper_plugin_elasticsearch_plugins extends DokuWiki_Plugin
+{
+    /**
+     * Update state of any changes for a page,
+     * e.g. plugins' data related to the page
+     *
+     * @param string $id
+     * @return bool
+     */
+    public function updateRefreshState($id) {
+        $refreshStateFile = metaFN($id, '.elasticsearch_refresh');
+        return io_saveFile($refreshStateFile, '');
+    }
+}


### PR DESCRIPTION
This PR provides new events that allow plugins to save additional page-related data into Elasticsearch index:

- `PLUGIN_ELASTICSEARCH_CREATEMAPPING` gathers additional index field definitions
- `PLUGIN_ELASTICSEARCH_INDEXPAGE` gathers the values of those additional fields

In addition, the public helper method `\helper_plugin_elasticsearch_plugins::updateRefreshState` lets plugins inform elastic that re-indexing is due, even if the page content itself has not changed.

Two more events let plugins integrate into the search itself:

- `PLUGIN_ELASTICSEARCH_FILTERS` will add a checkbox filter to advanced search tools, based on provided configuration
- `PLUGIN_ELASTICSEARCH_QUERY` lets plugins manipulate the query string, as well as provide some additions that should be appended, e.g. `#foo` when option foo is selected in the plugin's search filter