### PR TITLE
Language analyzers

### DIFF
--- a/action/search.php
+++ b/action/search.php
@@ -31,9 +31,9 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
      * @var string[]
      */
     protected $searchFields = [
-        'title',
-        'abstract',
-        'content',
+        'title*',
+        'abstract*',
+        'content*',
         'uri',
     ];
 
@@ -101,7 +101,7 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
         Event::createAndTrigger('PLUGIN_ELASTICSEARCH_SEARCHFIELDS', $fields);
 
         if ($this->getConf('searchSyntax')) {
-            array_push($this->searchFields, 'syntax');
+            array_push($this->searchFields, 'syntax*');
         }
 
         // finally define the elastic query

--- a/helper/client.php
+++ b/helper/client.php
@@ -122,9 +122,11 @@ class helper_plugin_elasticsearch_client extends DokuWiki_Plugin {
         $index = $client->getIndex($this->getConf('indexname'));
         $type = $index->getType($this->getConf('documenttype'));
 
-        // default language
-        $props = [
-            'content' => [
+        $langFields = ['title', 'abstract', 'content', 'syntax'];
+
+        foreach ($langFields as $langField) {
+            // default language
+            $props[$langField] = [
                 'type'  => 'text',
                 'fields' => [
                     $conf['lang'] => [
@@ -132,19 +134,19 @@ class helper_plugin_elasticsearch_client extends DokuWiki_Plugin {
                         'analyzer' => $this->getLanguageAnalyzer($conf['lang'])
                     ],
                 ]
-            ]
-        ];
+            ];
 
-        // other languages as configured in the translation plugin
-        /** @var helper_plugin_translation $transplugin */
-        $transplugin = plugin_load('helper', 'translation');
-        if ($transplugin) {
-            $translations = array_diff(array_filter($transplugin->translations), [$conf['lang']]);
-            if ($translations) foreach ($translations as $lang) {
-                $props['content']['fields'][$lang] = [
-                    'type' => 'text',
-                    'analyzer' => $this->getLanguageAnalyzer($lang)
-                ];
+            // other languages as configured in the translation plugin
+            /** @var helper_plugin_translation $transplugin */
+            $transplugin = plugin_load('helper', 'translation');
+            if ($transplugin) {
+                $translations = array_diff(array_filter($transplugin->translations), [$conf['lang']]);
+                if ($translations) foreach ($translations as $lang) {
+                    $props[$langField]['fields'][$lang] = [
+                        'type' => 'text',
+                        'analyzer' => $this->getLanguageAnalyzer($lang)
+                    ];
+                }
             }
         }
 


### PR DESCRIPTION
Fixes recent regression which disabled fuzzy search.

The PR also expands the list of fields with attached analyzers, so now fuzzy search works in title, abstract and syntax in addition to content.