### PR TITLE
Make max_analyzed_offset configurable and apply it on search

### DIFF
--- a/action/search.php
+++ b/action/search.php
@@ -122,6 +122,7 @@ class action_plugin_elasticsearch_search extends DokuWiki_Action_Plugin {
             [
                 "pre_tags"  => ['ELASTICSEARCH_MARKER_IN'],
                 "post_tags" => ['ELASTICSEARCH_MARKER_OUT'],
+                "max_analyzed_offset" => $this->getConf('maxAnalyzedOffset'),
                 "fields"    => [
                     $this->getConf('snippets') => new \stdClass(),
                     'title' => new \stdClass()]

--- a/conf/default.php
+++ b/conf/default.php
@@ -14,3 +14,4 @@ $conf['searchSyntax'] = 1;
 $conf['perpage']      = 20;
 $conf['detectTranslation'] = 0;
 $conf['disableQuicksearch'] = 0;
+$conf['maxAnalyzedOffset'] = 1000000;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -14,3 +14,4 @@ $meta['searchSyntax'] = array('onoff');
 $meta['perpage']      = array('numeric', '_min' => 1);
 $meta['detectTranslation'] = array('onoff');
 $meta['disableQuicksearch'] = array('onoff');
+$meta['maxAnalyzedOffset'] = array('numeric', '_min' => 0, '_caution' => 'warning');

--- a/helper/client.php
+++ b/helper/client.php
@@ -97,6 +97,10 @@ class helper_plugin_elasticsearch_client extends DokuWiki_Plugin {
             throw new \splitbrain\phpcli\Exception("Failed to create index!");
         }
 
+        if ($index->setSettings(['index.highlight.max_analyzed_offset' => $this->getConf('maxAnalyzedOffset')])->hasError()) {
+            throw new \splitbrain\phpcli\Exception("Could not set highlighting config on index!");
+        }
+
         if ($this->createMappings($index)->hasError()) {
             throw new \splitbrain\phpcli\Exception("Failed to create field mappings!");
         }

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -14,3 +14,4 @@ $lang['searchSyntax'] = 'Wiki-Syntax zusätzlich zum Seiteninhalt durchsuchen';
 $lang['perpage']      = 'Anzahl der Treffer pro Seite';
 $lang['detectTranslation'] = 'Translation Plugin Integration: Zunächst im aktuellen Übersetzungnamensraum suchen';
 $lang['disableQuicksearch'] = 'Schnellsuche deaktivieren (Vorschläge von passenden Seiten IDs)';
+$lang['maxAnalyzedOffset'] = 'Maximale Datenmenge pro Seite/Datei zur Hervorhebung von Suchtreffern. Nach Änderung dieses Wertes muss der Suchindex neu aufgebaut werden.';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -14,3 +14,4 @@ $lang['searchSyntax'] = 'Search in wiki syntax in addition to page content';
 $lang['perpage']      = 'How many hits to show per page';
 $lang['detectTranslation'] = 'Translation plugin support: search in current language namespace by default';
 $lang['disableQuicksearch'] = 'Disable quick search (page id suggestions)';
+$lang['maxAnalyzedOffset'] = 'Maximum amount of data per page/media file considered for search result highlighting. You have to recreate your index if you change this value.';


### PR DESCRIPTION
Elasticsearch has a per-index setting `index.highlight.max_analyzed_offset` that governs how much of the indexed data is analyzed for search result snippet highlighting. Searches have a corresponding `max_analyzed_offset` option. Without that search option if a search finds results in indexed media files that are larger than the default setting (about 1MB) you get an error.

This PR makes the index setting configurable and ensures that a matching option is set when querying the index to avoid running into abovementioned error condition.